### PR TITLE
Evaluate over specificly provided datasets

### DIFF
--- a/chunking_evaluation/__init__.py
+++ b/chunking_evaluation/__init__.py
@@ -1,10 +1,12 @@
 from .chunking.base_chunker import BaseChunker
 from .evaluation_framework.general_evaluation import GeneralEvaluation
 from .evaluation_framework.synthetic_evaluation import SyntheticEvaluation
+from .evaluation_framework.dataset_evaluation import DatasetEvaluation
 from .utils import *
 
 __all__ = [
     'BaseChunker',
     'GeneralEvaluation',
     'SyntheticEvaluation',
+    'DatasetEvaluation'
 ]

--- a/chunking_evaluation/__init__.py
+++ b/chunking_evaluation/__init__.py
@@ -1,12 +1,13 @@
 from .chunking.base_chunker import BaseChunker
 from .evaluation_framework.general_evaluation import GeneralEvaluation
 from .evaluation_framework.synthetic_evaluation import SyntheticEvaluation
-from .evaluation_framework.dataset_evaluation import DatasetEvaluation
+from .evaluation_framework.dataset_evaluation import DatasetEvaluation, Dataset
 from .utils import *
 
 __all__ = [
     'BaseChunker',
     'GeneralEvaluation',
     'SyntheticEvaluation',
-    'DatasetEvaluation'
+    'DatasetEvaluation',
+    'Dataset'
 ]

--- a/chunking_evaluation/evaluation_framework/dataset_evaluation.py
+++ b/chunking_evaluation/evaluation_framework/dataset_evaluation.py
@@ -25,7 +25,7 @@ class DatasetEvaluation(GeneralEvaluation):
         super().__init__(chroma_db_path=chroma_db_path)
 
     def _load_questions_df(self):
-        """Filters corpus and questions to consist of only provided datatasets values"""
+        """Filters the `corpus_list` and `questions_df` to include only the provided dataset values."""
         super()._load_questions_df()
 
         # filter questions

--- a/chunking_evaluation/evaluation_framework/dataset_evaluation.py
+++ b/chunking_evaluation/evaluation_framework/dataset_evaluation.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import override
 
 from .general_evaluation import GeneralEvaluation
 

--- a/chunking_evaluation/evaluation_framework/dataset_evaluation.py
+++ b/chunking_evaluation/evaluation_framework/dataset_evaluation.py
@@ -15,6 +15,10 @@ class Dataset(Enum):
 class DatasetEvaluation(GeneralEvaluation):
 
     def __init__(self, datasets: list[Dataset], chroma_db_path=None):
+        # edge cases handling
+        if len(datasets) == 0:
+            raise ValueError('The `datasets` list argument is empty')
+
         for dataset in datasets:
             if not isinstance(dataset, Dataset):
                 raise TypeError('The `datasets` parameter must be a list of Dataset enum instance')

--- a/chunking_evaluation/evaluation_framework/dataset_evaluation.py
+++ b/chunking_evaluation/evaluation_framework/dataset_evaluation.py
@@ -24,7 +24,6 @@ class DatasetEvaluation(GeneralEvaluation):
 
         super().__init__(chroma_db_path=chroma_db_path)
 
-    @override
     def _load_questions_df(self):
         """Filters corpus and questions to consist of only provided datatasets values"""
         super()._load_questions_df()

--- a/chunking_evaluation/evaluation_framework/dataset_evaluation.py
+++ b/chunking_evaluation/evaluation_framework/dataset_evaluation.py
@@ -1,0 +1,38 @@
+from enum import Enum
+from typing import override
+
+from .general_evaluation import GeneralEvaluation
+
+
+class Dataset(Enum):
+    CHATLOGS = 'chatlogs'
+    FINANCE = 'finance'
+    PUBMED = 'pubmed'
+    STATE_OF_THE_UNION = 'state_of_the_union'
+    WIKITEXTS = 'wikitexts'
+
+
+class DatasetEvaluation(GeneralEvaluation):
+
+    def __init__(self, datasets: list[Dataset], chroma_db_path=None):
+        for dataset in datasets:
+            if not isinstance(dataset, Dataset):
+                raise TypeError('The `datasets` parameter must be a list of Dataset enum instance')
+
+        # maps enums to their values
+        self._datasets: set[str] = set(map(lambda item: item.value, datasets))
+
+        super().__init__(chroma_db_path=chroma_db_path)
+
+    @override
+    def _load_questions_df(self):
+        """Filters corpus and questions to consist of only provided datatasets values"""
+        super()._load_questions_df()
+
+        # filter questions
+        filtered_questions = self.questions_df[self.questions_df['corpus_id'].isin(self._datasets)]
+        self.questions_df = filtered_questions
+
+        # filter corpus list
+        filtered_corpus = list(filter(lambda item: item in self._datasets, self.corpus_list))
+        self.corpus_list = filtered_corpus

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ setup(
         "python-Levenshtein",
         "openai",
         "anthropic",
-        "attrs"
+        "attrs",
+        "pytest"
     ],
     author="Brandon A. Smith",
     author_email="brandonsmithpmpuk@gmail.com",

--- a/tests/test_dataset_evaluation.py
+++ b/tests/test_dataset_evaluation.py
@@ -6,6 +6,11 @@ from chunking_evaluation.evaluation_framework.dataset_evaluation import DatasetE
 QUESTIONS_DF_PATH = './chunking_evaluation/evaluation_framework/general_evaluation_data/questions_df.csv'
 
 
+def test_does_not_accept_empty_list():
+    with pytest.raises(ValueError, match='The `datasets` list argument is empty'):
+        DatasetEvaluation(datasets=[])
+
+
 def test_accepts_only_dataset_enum_values():
     with pytest.raises(TypeError, match='The `datasets` parameter must be a list of Dataset enum instance'):
         DatasetEvaluation(

--- a/tests/test_dataset_evaluation.py
+++ b/tests/test_dataset_evaluation.py
@@ -1,0 +1,69 @@
+import pytest
+import pandas as pd
+
+from chunking_evaluation.evaluation_framework.dataset_evaluation import DatasetEvaluation, Dataset
+
+QUESTIONS_DF_PATH = './chunking_evaluation/evaluation_framework/general_evaluation_data/questions_df.csv'
+
+
+def test_accepts_only_dataset_enum_values():
+    with pytest.raises(TypeError, match='The `datasets` parameter must be a list of Dataset enum instance'):
+        DatasetEvaluation(
+            datasets=['chatlogs', 'finance']
+        )
+
+
+def test_maps_enum_values_to_datasets():
+    dataset_eval = DatasetEvaluation(
+        datasets=[
+            Dataset.FINANCE,
+            Dataset.CHATLOGS
+        ]
+    )
+
+    assert dataset_eval._datasets == {'finance', 'chatlogs'}
+
+
+def test_ignores_duplicate_dataset_names():
+    dataset_eval = DatasetEvaluation(
+        datasets=[
+            Dataset.FINANCE,
+            Dataset.FINANCE,
+            Dataset.FINANCE,
+            Dataset.CHATLOGS,
+            Dataset.CHATLOGS,
+        ]
+    )
+
+    assert len(dataset_eval._datasets) == 2
+    assert dataset_eval._datasets == {'finance', 'chatlogs'}
+
+
+def test_filters_corpus_list_based_on_datasets():
+    dataset_eval = DatasetEvaluation(
+        datasets=[Dataset.PUBMED, Dataset.WIKITEXTS]
+    )
+
+    assert sorted(dataset_eval.corpus_list) == sorted(['pubmed', 'wikitexts'])
+
+
+def test_filters_questions_df_based_on_datasets():
+    dataset_eval = DatasetEvaluation(
+        datasets=[Dataset.STATE_OF_THE_UNION, Dataset.FINANCE]
+    )
+
+    questions_df = pd.read_csv(QUESTIONS_DF_PATH)
+    filtered_df = questions_df[questions_df['corpus_id'].isin(['state_of_the_union', 'finance'])]
+
+    assert len(filtered_df) == len(dataset_eval.questions_df)
+
+
+def test_loads_all_questions_df_and_corresponding_corpus():
+    dataset_eval = DatasetEvaluation(
+        datasets=[Dataset.STATE_OF_THE_UNION, Dataset.FINANCE, Dataset.CHATLOGS, Dataset.PUBMED, Dataset.WIKITEXTS]
+    )
+    assert sorted(dataset_eval.corpus_list) == sorted(
+        ['state_of_the_union', 'finance', 'chatlogs', 'pubmed', 'wikitexts'])
+
+    questions_df = pd.read_csv(QUESTIONS_DF_PATH)
+    assert len(questions_df) == len(dataset_eval.questions_df)


### PR DESCRIPTION
### overview 

While evaluating some of my chunking algorithm ideas, I encountered an issue: `GeneralEvaluation` class, which includes all questions and all corpora datasets, takes too much time to evaluate (in my case, hours). 

To address this, I developed the `DatasetEvaluation` class, which inherits from `GeneralEvaluation` and accepts a list of dataset names to include in the evaluation. It filters the `questions_df` and `corpus_list` properties accordingly.

### unit tests

I also included unit tests for the `DatasetEvaluation` class in `tests/test_dataset_evaluation.py`.  To run them, the pytest package should be installed.

To run the tests, navigate to the root project directory:

```bash
cd ./chunking_evaluation 
```

Then, run:

```bash
pytest
```

### usage example

```python
import time

from chunking_evaluation import DatasetEvaluation, GeneralEvaluation, Dataset
from chunking_evaluation.chunking import FixedTokenChunker
from chromadb.utils import embedding_functions
from rich import print

ef = embedding_functions.SentenceTransformerEmbeddingFunction(
    model_name="all-MiniLM-L6-v2"
)
chunker = FixedTokenChunker()
eval = DatasetEvaluation(
    datasets=[
        Dataset.PUBMED,
        Dataset.WIKITEXTS,
        Dataset.CHATLOGS,
        Dataset.FINANCE,
        Dataset.STATE_OF_THE_UNION,
    ]
)

if __name__ == '__main__':
    start = time.time()
    results = eval.run(chunker, ef)
    end = time.time()

    print(results)
    print(f'TIME: {end - start}')
```
